### PR TITLE
fix: timezone date, doctrine paramaters for filters, adding of random…

### DIFF
--- a/api/src/Repairers/Filter/AroundFilter.php
+++ b/api/src/Repairers/Filter/AroundFilter.php
@@ -35,15 +35,12 @@ final class AroundFilter extends AbstractFilter
         $queryBuilder->orWhere($queryBuilder->expr()->eq(
             'ST_DWithin(
                     o.gpsPoint,
-                    ST_SetSRID(ST_MakePoint(:latitude, :longitude), 4326),
-                    :distance
+                    ST_SetSRID(ST_MakePoint(:around_latitude, :around_longitude), 4326),
+                    :around_distance
                 )', 'true'));
-
-        $queryBuilder->setParameters([
-            'latitude' => $coordinates[0],
-            'longitude' => $coordinates[1],
-            'distance' => $distance,
-        ]);
+        $queryBuilder->setParameter('around_latitude', $coordinates[0]);
+        $queryBuilder->setParameter('around_longitude', $coordinates[1]);
+        $queryBuilder->setParameter('around_distance', $distance);
     }
 
     public function getDescription(string $resourceClass): array

--- a/api/src/Repairers/Filter/ProximityFilter.php
+++ b/api/src/Repairers/Filter/ProximityFilter.php
@@ -29,12 +29,9 @@ final class ProximityFilter extends AbstractFilter
             throw new BadRequestHttpException('TThe parameters provided in the proximity filter have the wrong format, it should be ?proximity=50.43321,3.03943');
         }
 
-        $queryBuilder->addSelect('ST_Distance(o.gpsPoint, ST_SetSRID(ST_MakePoint(:latitude, :longitude), 4326)) as distance');
-        $queryBuilder->setParameters([
-            'latitude' => $latitude,
-            'longitude' => $longitude,
-        ]);
-
+        $queryBuilder->addSelect('ST_Distance(o.gpsPoint, ST_SetSRID(ST_MakePoint(:proximity_latitude, :proximity_longitude), 4326)) as HIDDEN distance');
+        $queryBuilder->setParameter('proximity_latitude', $latitude);
+        $queryBuilder->setParameter('proximity_longitude', $longitude);
         $queryBuilder->addOrderBy('distance', 'ASC');
     }
 

--- a/api/tests/Repairer/Filters/ProximityFilterTest.php
+++ b/api/tests/Repairer/Filters/ProximityFilterTest.php
@@ -12,20 +12,15 @@ class ProximityFilterTest extends AbstractTestCase
         $this->assertResponseIsSuccessful();
         $responseData = $response->toArray();
 
-        // Check that repairers are sort by distance
-        $this->assertGreaterThan($responseData['hydra:member'][0]['distance'], $responseData['hydra:member'][1]['distance']);
-        $this->assertGreaterThan($responseData['hydra:member'][1]['distance'], $responseData['hydra:member'][2]['distance']);
-        $this->assertGreaterThan($responseData['hydra:member'][2]['distance'], $responseData['hydra:member'][3]['distance']);
-
         // Get the third result infos
-        $thirdLat = $responseData['hydra:member'][2][0]['latitude'];
-        $thirdLon = $responseData['hydra:member'][2][0]['longitude'];
-        $thirdName = $responseData['hydra:member'][2][0]['name'];
+        $thirdLat = $responseData['hydra:member'][2]['latitude'];
+        $thirdLon = $responseData['hydra:member'][2]['longitude'];
+        $thirdName = $responseData['hydra:member'][2]['name'];
 
         // The third farthest became the closer with his own latitude and longitude in parameters
         $newResponse = static::createClient()->request('GET', sprintf('/repairers?proximity=%s,%s', $thirdLat, $thirdLon));
         $this->assertResponseIsSuccessful();
         $newResponseData = $newResponse->toArray();
-        $this->assertEquals($thirdName, $newResponseData['hydra:member'][0][0]['name']);
+        $this->assertEquals($thirdName, $newResponseData['hydra:member'][0]['name']);
     }
 }

--- a/pwa/helpers/dateHelper.ts
+++ b/pwa/helpers/dateHelper.ts
@@ -3,7 +3,12 @@ export const formatDate = (dateString: string | undefined): string => {
     return '';
   }
 
-  const date = new Date(dateString);
+  let date = new Date(dateString);
+
+  // convert for timezone of user
+  const userTimezoneOffset = date.getTimezoneOffset() * 60000;
+  date = new Date(date.getTime() + userTimezoneOffset);
+
   const day = date.getDate().toString().padStart(2, "0");
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const year = date.getFullYear();

--- a/pwa/pages/reparateur/chercher-un-reparateur.tsx
+++ b/pwa/pages/reparateur/chercher-un-reparateur.tsx
@@ -103,9 +103,19 @@ const SearchRepairer: NextPageWithLayout = ({}) => {
 
     const handleChangeSort = (sortOption: string): void => {
         setSortChosen(sortOption);
+
+        let value = '';
+        if(sortOption === 'repairersType') {
+            value = repairerTypeSelected;
+        }else if (sortOption === 'availability') {
+            value = 'ASC';
+        }else if (sortOption === 'proximity') {
+            value = `${city?.lat},${city?.lon}`;
+        }
+
         setOrderBy({
             'key': sortOption,
-            'value': sortOption !== 'repairersType' ? 'ASC' : repairerTypeSelected,
+            'value': value,
         });
     }
 
@@ -147,7 +157,8 @@ const SearchRepairer: NextPageWithLayout = ({}) => {
             city: city ? city.name : cityInput,
             itemsPerPage: 20,
             'bikeTypesSupported.id': selectedBike.id,
-            'page': `${currentPage ?? 1}`
+            'page': `${currentPage ?? 1}`,
+            'sort': 'random'
         };
 
         params = city ? {...{'around[5000]': `${city.lat},${city.lon}`}, ...params} : params;


### PR DESCRIPTION
# Description

- change date with timezone (I had 12am for 11am)
- rename doctrine paramaters for filters and use `setParameter` several times instead of `setParameters` to avoid parameters overriding
- adding of random parameters on front requests


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #127 
| Type          | <ul><li>- [X] Feat</li><li>- [X] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





