### PR TITLE
Add a doctrine extension for repairer enabled

### DIFF
--- a/api/src/Repairers/Doctrine/EnabledRepairersExtension.php
+++ b/api/src/Repairers/Doctrine/EnabledRepairersExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Repairers\Doctrine;
+
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use App\Entity\Repairer;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Bundle\SecurityBundle\Security;
+
+final class EnabledRepairersExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+{
+    private $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void
+    {
+        $this->addWhere($queryBuilder, $resourceClass);
+    }
+
+    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, Operation $operation = null, array $context = []): void
+    {
+
+    }
+
+    private function addWhere(QueryBuilder $queryBuilder, string $resourceClass): void
+    {
+        if (Repairer::class !== $resourceClass || $this->security->isGranted('ROLE_ADMIN')) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder->andWhere(sprintf('%s.enabled = :enabled', $rootAlias))
+            ->setParameter('enabled', true);
+    }
+}

--- a/api/tests/Repairer/SecurityRepairerTest.php
+++ b/api/tests/Repairer/SecurityRepairerTest.php
@@ -102,12 +102,12 @@ class SecurityRepairerTest extends AbstractTestCase
 
     public function testGetRepairerCollectionFilterByEnabled(): void
     {
-        $client = self::createClientAuthAsAdmin();
-        // admin user given
-        $response = $client->request('GET', '/repairers?enabled=true');
+        $client = self::createClientAuthAsUser();
+        // classic user given
+        $response = $client->request('GET', '/repairers');
         $this->assertResponseIsSuccessful();
         $response = $response->toArray();
-        // On 25 repairers -> 3 aren't enabled
+        // Test doctrine extension, same route but different result because different role
         $this->assertCount(22, $response['hydra:member']);
     }
 
@@ -191,7 +191,7 @@ class SecurityRepairerTest extends AbstractTestCase
        $client = self::createClientWithUserId(41);
 
         // Valid user role given
-       $client->request('PUT', '/repairers/21', [
+       $response = $client->request('PUT', '/repairers/21', [
             'headers' => ['Content-Type' => 'application/json'],
             'json' => [
                 'description' => 'test put enabled failed',
@@ -199,7 +199,6 @@ class SecurityRepairerTest extends AbstractTestCase
             ],
         ]);
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
-
         //Get the user 21 by admin to access to the enabled property
         $admin = self::createClientAuthAsAdmin();
         $response2 = $admin->request('GET', '/repairers/21');


### PR DESCRIPTION
# Description

Create a doctrine extension to get all repairers for admin and only the enabled repairers for user. Adapt tests to these changes


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #161..
| Type          | <ul><li>- [x] Feat</li><li>- [ ] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





