### PR TITLE
feat: adding interventions

### DIFF
--- a/api/fixtures/intervention.yaml
+++ b/api/fixtures/intervention.yaml
@@ -1,0 +1,19 @@
+App\Entity\Intervention:
+  intervention_admin_1:
+    description: "Changement d'une roue"
+    isAdmin: true
+  intervention_admin_2:
+    description: "Révision"
+    isAdmin: true
+  intervention_boss_1:
+    description: "Réglage des freins"
+    isAdmin: false
+  intervention_boss_2:
+    description: "Installation de lumières"
+    isAdmin: false
+  intervention_admin_3:
+    description: "Installation d'une béquille"
+    isAdmin: true
+  intervention_boss_3:
+    description: "Réglage du guidon"
+    isAdmin: false

--- a/api/fixtures/repairer_intervention.yaml
+++ b/api/fixtures/repairer_intervention.yaml
@@ -1,0 +1,17 @@
+App\Entity\RepairerIntervention:
+  repairer_intervention_1:
+    price: 5000
+    repairer: '@repairer_1'
+    intervention: '@intervention_admin_1'
+  repairer_intervention_2:
+    price: 10000
+    repairer: '@repairer_1'
+    intervention: '@intervention_boss_1'
+  repairer_intervention_3:
+    price: 10000
+    repairer: '@repairer_24'
+    intervention: '@intervention_boss_2'
+  repairer_intervention_{4..20}:
+    price: 15000
+    repairer: '@repairer_3'
+    intervention: '@intervention_boss_1'

--- a/api/fixtures/user.yaml
+++ b/api/fixtures/user.yaml
@@ -13,6 +13,13 @@ App\Entity\User:
     lastName: 'Tilleuls'
     plainPassword: "Test1passwordOk!"
     emailConfirmed: true
+  boss_2:
+    roles: [ "ROLE_BOSS" ]
+    email: "boss2@test.com"
+    firstName: <firstName()>
+    lastName: <lastName()>
+    plainPassword: "Test1passwordOk!"
+    emailConfirmed: true
   user_1:
     roles: ["ROLE_USER"]
     email: "user1@test.com"

--- a/api/migrations/Version20230414121420.php
+++ b/api/migrations/Version20230414121420.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230414121420 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add intervention and repairer_intervention tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SEQUENCE intervention_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE SEQUENCE repairer_intervention_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE intervention (id INT NOT NULL, description VARCHAR(255) NOT NULL, is_admin BOOLEAN NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE repairer_intervention (id INT NOT NULL, repairer_id INT DEFAULT NULL, intervention_id INT DEFAULT NULL, price INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_4DCEB81F47C5DFEE ON repairer_intervention (repairer_id)');
+        $this->addSql('CREATE INDEX IDX_4DCEB81F8EAE3863 ON repairer_intervention (intervention_id)');
+        $this->addSql('ALTER TABLE repairer_intervention ADD CONSTRAINT FK_4DCEB81F47C5DFEE FOREIGN KEY (repairer_id) REFERENCES repairer (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE repairer_intervention ADD CONSTRAINT FK_4DCEB81F8EAE3863 FOREIGN KEY (intervention_id) REFERENCES intervention (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('DROP SEQUENCE intervention_id_seq CASCADE');
+        $this->addSql('DROP SEQUENCE repairer_intervention_id_seq CASCADE');
+        $this->addSql('ALTER TABLE repairer_intervention DROP CONSTRAINT FK_4DCEB81F47C5DFEE');
+        $this->addSql('ALTER TABLE repairer_intervention DROP CONSTRAINT FK_4DCEB81F8EAE3863');
+        $this->addSql('DROP TABLE intervention');
+        $this->addSql('DROP TABLE repairer_intervention');
+    }
+}

--- a/api/src/Entity/Intervention.php
+++ b/api/src/Entity/Intervention.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use App\Intervention\Dto\CreateInterventionRepairerDto;
+use App\Intervention\Filter\OwnerFilter;
+use App\Intervention\State\CreateInterventionWithCurrentRepairerProcessor;
+use App\Repository\InterventionRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+#[ORM\Entity(repositoryClass: InterventionRepository::class)]
+#[ApiResource(
+    normalizationContext: ['groups' => [self::READ]],
+    denormalizationContext: ['groups' => [self::WRITE]],
+)]
+#[Get]
+#[GetCollection]
+#[Post(
+    security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_BOSS')",
+    input: CreateInterventionRepairerDto::class,
+    processor: CreateInterventionWithCurrentRepairerProcessor::class,
+)]
+#[Put(security: "is_granted('ROLE_ADMIN') or (!object.isAdmin and object.canAccess(user))")]
+#[Delete(security: "is_granted('ROLE_ADMIN') or (!object.isAdmin and object.canAccess(user))")]
+#[ApiFilter(SearchFilter::class, properties: ['isAdmin' => 'exact'])]
+#[ApiFilter(OwnerFilter::class)]
+class Intervention
+{
+    public const READ = 'intervention_read';
+    public const WRITE = 'intervention_write';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Groups([self::READ])]
+    public ?int $id;
+
+    #[ORM\Column(length: 255)]
+    #[Groups([self::READ, self::WRITE])]
+    public ?string $description = null;
+
+    #[ORM\Column]
+    #[Groups([self::READ])]
+    public ?bool $isAdmin = null;
+
+    #[ORM\OneToMany(mappedBy: 'intervention', targetEntity: RepairerIntervention::class, cascade: ['persist', 'remove'])]
+    public Collection $repairerInterventions;
+
+    public function __construct()
+    {
+        $this->repairerInterventions = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection<int, RepairerIntervention>
+     */
+    public function getRepairerInterventions(): Collection
+    {
+        return $this->repairerInterventions;
+    }
+
+    public function addRepairerIntervention(RepairerIntervention $repairerIntervention): self
+    {
+        if (!$this->repairerInterventions->contains($repairerIntervention)) {
+            $this->repairerInterventions->add($repairerIntervention);
+            $repairerIntervention->intervention = $this;
+        }
+
+        return $this;
+    }
+
+    public function removeRepairerIntervention(RepairerIntervention $repairerIntervention): self
+    {
+        if ($this->repairerInterventions->removeElement($repairerIntervention)) {
+            // set the owning side to null (unless already changed)
+            if ($repairerIntervention->intervention === $this) {
+                $repairerIntervention->intervention = null;
+            }
+        }
+
+        return $this;
+    }
+
+    public function canAccess(?User $user): bool
+    {
+        if (null === $user) {
+            return false;
+        }
+
+        foreach ($this->repairerInterventions as $repairerIntervention) {
+            if ($repairerIntervention->repairer->getOwner() === $user) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/api/src/Entity/Repairer.php
+++ b/api/src/Entity/Repairer.php
@@ -203,6 +203,9 @@ class Repairer
     #[Groups([self::REPAIRER_READ, self::REPAIRER_WRITE])]
     private ?string $comment = null;
 
+    #[ORM\OneToMany(mappedBy: 'repairer', targetEntity: RepairerIntervention::class, orphanRemoval: true)]
+    private Collection $repairerInterventions;
+
     public function __construct()
     {
         $this->bikeTypesSupported = new ArrayCollection();
@@ -488,6 +491,32 @@ class Repairer
     public function setComment(?string $comment): self
     {
         $this->comment = $comment;
+
+        return $this;
+    }
+
+    public function getRepairerInterventions(): Collection
+    {
+        return $this->repairerInterventions;
+    }
+
+    public function addRepairerIntervention(RepairerIntervention $repairerIntervention): self
+    {
+        if (!$this->repairerInterventions->contains($repairerIntervention)) {
+            $this->repairerInterventions->add($repairerIntervention);
+            $repairerIntervention->repairer = $this;
+        }
+
+        return $this;
+    }
+
+    public function removeRepairerIntervention(RepairerIntervention $repairerIntervention): self
+    {
+        if ($this->repairerInterventions->removeElement($repairerIntervention)) {
+            if ($repairerIntervention->repairer === $this) {
+                unset($repairerIntervention->repairer);
+            }
+        }
 
         return $this;
     }

--- a/api/src/Entity/RepairerIntervention.php
+++ b/api/src/Entity/RepairerIntervention.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use App\Repository\RepairerInterventionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity(repositoryClass: RepairerInterventionRepository::class)]
+#[ApiResource(
+    denormalizationContext: ['groups' => [self::WRITE]],
+)]
+#[Post(
+    security: "is_granted('ROLE_ADMIN') or is_granted('ROLE_BOSS')",
+)]
+class RepairerIntervention
+{
+    public const WRITE = 'repairer_intervention_write';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public ?int $id = null;
+
+    #[Assert\Positive, Assert\NotNull]
+    #[ORM\Column]
+    #[Groups([Intervention::READ, self::WRITE])]
+    public int $price;
+
+    #[ORM\ManyToOne(cascade: ['persist'], inversedBy: 'repairerInterventions')]
+    #[Groups([Intervention::READ])]
+    #[ORM\JoinColumn]
+    public Repairer $repairer;
+
+    #[Assert\NotNull]
+    #[ORM\ManyToOne(inversedBy: 'repairerInterventions')]
+    #[ORM\JoinColumn]
+    #[Groups([self::WRITE])]
+    public Intervention $intervention;
+}

--- a/api/src/Intervention/Dto/CreateInterventionRepairerDto.php
+++ b/api/src/Intervention/Dto/CreateInterventionRepairerDto.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Intervention\Dto;
+
+use App\Entity\Intervention;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class CreateInterventionRepairerDto
+{
+    #[Assert\NotBlank, Assert\NotNull]
+    #[Groups([Intervention::WRITE])]
+    public string $description;
+
+    #[Assert\GreaterThanOrEqual(0)]
+    #[Groups([Intervention::WRITE])]
+    public ?int $price = null;
+}

--- a/api/src/Intervention/Filter/OwnerFilter.php
+++ b/api/src/Intervention/Filter/OwnerFilter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Intervention\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\PropertyInfo\Type;
+
+class OwnerFilter extends AbstractFilter
+{
+    public const PROPERTY_NAME = 'owner';
+
+    protected function filterProperty(string $property, $value, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void
+    {
+        if (self::PROPERTY_NAME !== $property) {
+            return;
+        }
+
+        $queryBuilder->innerJoin('o.repairerInterventions', 'ri')
+            ->innerJoin('ri.repairer', 'r')
+            ->andWhere('r.owner = :owner')
+            ->setParameter('owner', $value);
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        if (!$this->properties) {
+            return [];
+        }
+
+        $description = [];
+        foreach ($this->properties as $strategy) {
+            $description['owner'] = [
+                'type' => Type::BUILTIN_TYPE_STRING,
+                'required' => false,
+                'description' => 'Allow to filter by boss ID',
+                'openapi' => [
+                    'example' => '/interventions?owner=12',
+                    'allowReserved' => false,
+                    'allowEmptyValue' => false,
+                    'explode' => false,
+                ],
+            ];
+        }
+
+        return $description;
+    }
+}

--- a/api/src/Intervention/State/CreateInterventionWithCurrentRepairerProcessor.php
+++ b/api/src/Intervention/State/CreateInterventionWithCurrentRepairerProcessor.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Intervention\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Intervention;
+use App\Entity\RepairerIntervention;
+use App\Entity\User;
+use App\Intervention\Dto\CreateInterventionRepairerDto;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Finder\Exception\AccessDeniedException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+final readonly class CreateInterventionWithCurrentRepairerProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $entityManager
+    ) {
+    }
+
+    /**
+     * @param CreateInterventionRepairerDto $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Intervention
+    {
+        /** @var ?User $user */
+        $user = $this->security->getUser();
+        if (!$user) {
+            throw new AccessDeniedException('You must be logged in to create an intervention');
+        }
+
+        $intervention = new Intervention();
+        $intervention->description = $data->description;
+        $intervention->isAdmin = $user->isAdmin();
+
+        if ($user->isBoss()) {
+            if (null === $data->price) {
+                throw new BadRequestHttpException('Price is required');
+            }
+            if (null === $user->repairer) {
+                throw new BadRequestHttpException('You must have a repairer to create an intervention');
+            }
+            $repairerIntervention = new RepairerIntervention();
+            $repairerIntervention->price = $data->price;
+            $repairerIntervention->repairer = $user->repairer;
+            $repairerIntervention->intervention = $intervention;
+            $intervention->addRepairerIntervention($repairerIntervention);
+        }
+
+        $this->entityManager->persist($intervention);
+        $this->entityManager->flush();
+
+        return $intervention;
+    }
+}

--- a/api/src/RepairerIntervention/EventSubscriber/RepairerInterventionEventSubscriber.php
+++ b/api/src/RepairerIntervention/EventSubscriber/RepairerInterventionEventSubscriber.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RepairerIntervention\EventSubscriber;
+
+use ApiPlatform\Symfony\EventListener\EventPriorities;
+use ApiPlatform\Validator\ValidatorInterface;
+use App\Entity\Intervention;
+use App\Entity\RepairerIntervention;
+use App\Entity\User;
+use App\Repository\InterventionRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+readonly class RepairerInterventionEventSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private InterventionRepository $interventionRepository,
+        private Security $security,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::VIEW => ['linkRepairerToAdminIntervention', EventPriorities::PRE_WRITE],
+        ];
+    }
+
+    public function linkRepairerToAdminIntervention(ViewEvent $event): void
+    {
+        $object = $event->getControllerResult();
+        $method = $event->getRequest()->getMethod();
+
+        if (!$object instanceof RepairerIntervention || !in_array($method, [Request::METHOD_POST, Request::METHOD_PUT], true)) {
+            return;
+        }
+
+        /** @var ?User $user */
+        $user = $this->security->getUser();
+
+        if (!$user) {
+            throw new UnauthorizedHttpException('Bearer realm="link repairer to intervention"');
+        }
+
+        if (null === $user->repairer) {
+            throw new AccessDeniedException('You need to have a repairer profile to link to an intervention');
+        }
+
+        /** @var ?Intervention $adminIntervention */
+        $adminIntervention = $this->interventionRepository->findOneBy(['id' => $object->intervention->id]);
+
+        if (null === $adminIntervention) {
+            throw new NotFoundHttpException(sprintf('Intervention with id %s not found', $object->intervention->id));
+        }
+
+        if (!$adminIntervention->isAdmin) {
+            throw new AccessDeniedException('You can only link repairers to interventions created by admin');
+        }
+
+        $object->repairer = $user->repairer;
+        $this->validator->validate($object);
+    }
+}

--- a/api/src/Repository/InterventionRepository.php
+++ b/api/src/Repository/InterventionRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Intervention;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Intervention>
+ *
+ * @method Intervention|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Intervention|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Intervention[]    findAll()
+ * @method Intervention[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class InterventionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Intervention::class);
+    }
+
+    public function save(Intervention $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(Intervention $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/api/src/Repository/RepairerInterventionRepository.php
+++ b/api/src/Repository/RepairerInterventionRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\RepairerIntervention;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RepairerIntervention>
+ *
+ * @method RepairerIntervention|null find($id, $lockMode = null, $lockVersion = null)
+ * @method RepairerIntervention|null findOneBy(array $criteria, array $orderBy = null)
+ * @method RepairerIntervention[]    findAll()
+ * @method RepairerIntervention[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class RepairerInterventionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RepairerIntervention::class);
+    }
+
+    public function save(RepairerIntervention $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(RepairerIntervention $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+}

--- a/api/tests/Intervention/CreateInterventionTest.php
+++ b/api/tests/Intervention/CreateInterventionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Intervention;
+
+use App\Tests\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateInterventionTest extends AbstractTestCase
+{
+    public function testAdminCanPost(): void
+    {
+        $client = $this->createClientAuthAsAdmin();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention admin !',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'description' => 'Une nouvelle intervention admin !',
+            'isAdmin' => true,
+        ]);
+    }
+
+    public function testAdminSetPrice(): void
+    {
+        $client = $this->createClientAuthAsAdmin();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention admin !',
+                'price' => 1000,
+            ],
+        ])->toArray();
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testBossCanPost(): void
+    {
+        $client = $this->createClientAuthAsBoss();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention boss !',
+                'price' => 1000,
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'description' => 'Une nouvelle intervention boss !',
+            'isAdmin' => false,
+        ]);
+    }
+
+    public function testBossForgetsPrice(): void
+    {
+        $client = $this->createClientAuthAsBoss();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention boss !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function testBossSetNegativePrice(): void
+    {
+        $client = $this->createClientAuthAsBoss();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention boss !',
+                'price' => -1000,
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testWithoutDescription(): void
+    {
+        $client = $this->createClientAuthAsBoss();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'price' => 1000,
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testUserCannotPost(): void
+    {
+        $client = $this->createClientAuthAsUser();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUnauthenticatedCannotPost(): void
+    {
+        $client = self::createClient();
+        $client->request('POST', '/interventions', [
+            'json' => [
+                'description' => 'Une nouvelle intervention !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/api/tests/Intervention/DeleteInterventionTest.php
+++ b/api/tests/Intervention/DeleteInterventionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Intervention;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteInterventionTest extends InterventionAbstractTestCase
+{
+    public function testAdminCanDeleteAdminIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = $this->createClientAuthAsAdmin();
+        $client->request('DELETE', sprintf('/interventions/%s', $id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+
+    public function testBossCannotDeleteAdminIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = $this->createClientAuthAsBoss();
+        $client->request('DELETE', sprintf('/interventions/%s', $id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testBossCanDeleteHisIntervention(): void
+    {
+        [$user, $intervention] = $this->getBossAndHisIntervention();
+        $client = $this->createClientWithUser($user);
+        $client->request('DELETE', sprintf('/interventions/%s', $intervention->id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+    }
+
+    public function testBossCannotDeleteOtherBossIntervention(): void
+    {
+        [$badBoss, $intervention] = $this->getBossAndOtherBossIntervention();
+        $client = $this->createClientWithUser($badBoss);
+        $client->request('DELETE', sprintf('/interventions/%s', $intervention->id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUserCannotDeleteIntervention(): void
+    {
+        $intervention = $this->getBossAndHisIntervention()[1];
+        $client = $this->createClientAuthAsUser();
+        $client->request('DELETE', sprintf('/interventions/%s', $intervention->id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUnauthenticatedCannotDeleteIntervention(): void
+    {
+        $intervention = $this->getBossAndHisIntervention()[1];
+        $client = self::createClient();
+        $client->request('DELETE', sprintf('/interventions/%s', $intervention->id));
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/api/tests/Intervention/GetInterventionTest.php
+++ b/api/tests/Intervention/GetInterventionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Intervention;
+
+use App\Entity\RepairerIntervention;
+use App\Entity\User;
+
+class GetInterventionTest extends InterventionAbstractTestCase
+{
+    public function testGetCollectionInterventionFromBoss(): void
+    {
+        $user = $this->getBossAndHisIntervention()[0];
+
+        // get all interventions from user
+        $expectedInterventions = array_map(static function (RepairerIntervention $repairerIntervention) {
+            return $repairerIntervention->intervention->id;
+        }, $user->repairer->getRepairerInterventions()->toArray());
+
+        $client = $this->createClientAuthAsBoss();
+        $response = $client->request('GET', sprintf('/interventions?owner=%s', $user->id))->toArray();
+
+        self::assertResponseIsSuccessful();
+        foreach ($response['hydra:member'] as $intervention) {
+            self::assertArrayHasKey('id', $intervention);
+            // check if retrieved intervention is in user interventions
+            self::assertContains($intervention['id'], $expectedInterventions);
+        }
+    }
+
+    public function testCanGetCollectionAdminInterventions(): void
+    {
+        $client = self::createClient();
+        $response = $client->request('GET', '/interventions?isAdmin=true')->toArray();
+
+        self::assertResponseIsSuccessful();
+        self::assertGreaterThan(1, $response['hydra:totalItems']);
+        foreach ($response['hydra:member'] as $intervention) {
+            self::assertArrayHasKey('id', $intervention);
+            self::assertArrayHasKey('description', $intervention);
+            self::assertArrayHasKey('isAdmin', $intervention);
+            self::assertEquals(true, $intervention['isAdmin']);
+        }
+    }
+
+    public function testCanGetIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = self::createClient();
+        $response = $client->request('GET', sprintf('/interventions/%d', $id))->toArray();
+        self::assertResponseIsSuccessful();
+        self::assertArrayHasKey('id', $response);
+        self::assertSame($id, $response['id']);
+    }
+}

--- a/api/tests/Intervention/InterventionAbstractTestCase.php
+++ b/api/tests/Intervention/InterventionAbstractTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Intervention;
+
+use App\Entity\Intervention;
+use App\Entity\User;
+use App\Repository\InterventionRepository;
+use App\Repository\UserRepository;
+use App\Tests\AbstractTestCase;
+
+class InterventionAbstractTestCase extends AbstractTestCase
+{
+    /** @var User[] */
+    protected array $users = [];
+
+    private InterventionRepository $interventionRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        $this->users = $userRepository->findAll();
+
+        /** @var InterventionRepository $interventionRepository */
+        $interventionRepository = self::getContainer()->get(InterventionRepository::class);
+        $this->interventionRepository = $interventionRepository;
+    }
+
+    protected function getAdminIntervention(): Intervention
+    {
+        $intervention = $this->interventionRepository->findOneBy(['isAdmin' => true]);
+
+        if (!$intervention) {
+            self::fail('No admin intervention found');
+        }
+
+        return $intervention;
+    }
+
+    public function getBossAndHisIntervention(): ?array
+    {
+        foreach ($this->users as $user) {
+            if (
+                null !== $user->repairer &&
+                $user->isBoss() &&
+                0 < $user->repairer->getRepairerInterventions()->count()
+            ) {
+                foreach ($user->repairer->getRepairerInterventions() as $repairerIntervention) {
+                    if (false === $repairerIntervention->intervention->isAdmin) {
+                        return [$user, $repairerIntervention->intervention];
+                    }
+                }
+            }
+        }
+        self::fail('No user with intervention found');
+    }
+
+    public function getBossAndOtherBossIntervention(): array
+    {
+        [$user, $intervention] = $this->getBossAndHisIntervention();
+        foreach ($this->users as $userIteration) {
+            if ($userIteration !== $user && $userIteration->isBoss()) {
+                return [$userIteration, $intervention];
+            }
+        }
+        self::fail('No user or intervention found for the test');
+    }
+}

--- a/api/tests/Intervention/UpdateInterventionTest.php
+++ b/api/tests/Intervention/UpdateInterventionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Intervention;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateInterventionTest extends InterventionAbstractTestCase
+{
+    public function testAdminCanPutAdminIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = $this->createClientAuthAsAdmin();
+        $client->request('PUT', sprintf('/interventions/%d', $id), [
+            'json' => [
+                'description' => 'Intervention modifiée testAdminCanPutAdminIntervention !',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'description' => 'Intervention modifiée testAdminCanPutAdminIntervention !',
+            'isAdmin' => true,
+        ]);
+    }
+
+    public function testAdminCanPutBossIntervention(): void
+    {
+        $intervention = $this->getBossAndHisIntervention()[1];
+        $client = $this->createClientAuthAsAdmin();
+        $client->request('PUT', sprintf('/interventions/%d', $intervention->id), [
+            'json' => [
+                'description' => 'Intervention modifiée testAdminCanPutBossIntervention !',
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'description' => 'Intervention modifiée testAdminCanPutBossIntervention !',
+            'isAdmin' => false,
+        ]);
+    }
+
+    public function testBossCanPutHisIntervention(): void
+    {
+        [$user, $intervention] = $this->getBossAndHisIntervention();
+        $client = $this->createClientWithUser($user);
+        $client->request('PUT', sprintf('/interventions/%d', $intervention->id), [
+            'json' => [
+                'description' => 'Intervention testBossCanPutHisIntervention !',
+                'price' => 5000,
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'description' => 'Intervention testBossCanPutHisIntervention !',
+            'isAdmin' => false,
+        ]);
+    }
+
+    public function testBossCannotPutAdminIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = $this->createClientAuthAsBoss();
+        $client->request('PUT', sprintf('/interventions/%d', $id), [
+            'json' => [
+                'description' => 'Intervention modifiée !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testBossCannotPutOtherBossIntervention(): void
+    {
+        [$badBoss, $intervention] = $this->getBossAndOtherBossIntervention();
+        $client = $this->createClientWithUser($badBoss);
+        $client->request('PUT', sprintf('/interventions/%d', $intervention->id), [
+            'json' => [
+                'description' => 'Intervention modifiée !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUserCannotPutIntervention(): void
+    {
+        $intervention = $this->getBossAndHisIntervention()[1];
+        $client = $this->createClientAuthAsUser();
+        $client->request('PUT', sprintf('/interventions/%d', $intervention->id), [
+            'json' => [
+                'description' => 'Intervention modifiée !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testUnauthenticatedCannotPutIntervention(): void
+    {
+        $intervention = $this->getBossAndHisIntervention()[1];
+        $client = self::createClient();
+        $client->request('PUT', sprintf('/interventions/%d', $intervention->id), [
+            'json' => [
+                'description' => 'Intervention modifiée !',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+}

--- a/api/tests/Repairer/SecurityRepairerTest.php
+++ b/api/tests/Repairer/SecurityRepairerTest.php
@@ -148,7 +148,21 @@ class SecurityRepairerTest extends AbstractTestCase
 
     public function testOwnerCreatedByUser(): void
     {
-        $client = self::createClientWithUser($this->users[93]);
+        /** @var ?User $user */
+        $user = null;
+
+        foreach ($this->users as $userIteration) {
+            if (null === $userIteration->repairer) {
+                $user = $userIteration;
+                break;
+            }
+        }
+
+        if (null === $user) {
+            $this->fail('No user found without repairer');
+        }
+
+        $client = self::createClientWithUser($user);
 
         // simple user given
         $response = $client->request('POST', '/repairers', [
@@ -166,7 +180,7 @@ class SecurityRepairerTest extends AbstractTestCase
         $response = $response->toArray();
         $this->assertResponseIsSuccessful();
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
-        $this->assertSame($response['owner'], '/users/'.$this->users[93]->id);
+        $this->assertSame($response['owner'], '/users/'.$user->id);
         $this->assertSame($response['comment'], 'Je voulais juste ajouter un commentaire');
     }
 

--- a/api/tests/RepairerIntervention/CreateRepairerInterventionTest.php
+++ b/api/tests/RepairerIntervention/CreateRepairerInterventionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\RepairerIntervention;
+
+use App\Tests\Intervention\InterventionAbstractTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CreateRepairerInterventionTest extends InterventionAbstractTestCase
+{
+    public function testBossCanLinkRepairerToAdminIntervention(): void
+    {
+        $id = $this->getAdminIntervention()->id;
+        $client = $this->createClientAuthAsBoss();
+        $response = $client->request('POST', '/repairer_interventions', [
+            'json' => [
+                'intervention' => sprintf('/interventions/%s', $id),
+                'price' => 100,
+            ],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertArrayHasKey('repairer', $response->toArray());
+        self::assertJsonContains([
+            'intervention' => sprintf('/interventions/%s', $id),
+            'price' => 100,
+        ]);
+    }
+
+    public function testBossCannotLinkToOtherBossIntervention(): void
+    {
+        [$badBoss, $intervention] = $this->getBossAndOtherBossIntervention();
+        $client = $this->createClientWithUser($badBoss);
+        $client->request('POST', '/repairer_interventions', [
+            'json' => [
+                'intervention' => sprintf('/interventions/%s', $intervention->id),
+                'price' => 100,
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+}


### PR DESCRIPTION
# Description

Adding of intervention, linked to Repairer with RepairerIntervention entity. Admin and Boss can post interventions. Boss should specify price to create link between new intervention and his repairer. Boss can link his repairer to admin interventions with POST /repairer_interventions


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #147 
| Type          | <ul><li>- [x] Feat</li><li>- [ ] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





