### PR TITLE
feat: add annotation for nginx ingress (proxy-body-size)

### DIFF
--- a/helm/chart/values.yml
+++ b/helm/chart/values.yml
@@ -142,6 +142,7 @@ service:
 ingress:
   enabled: true
   annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 5m
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:


### PR DESCRIPTION
# Description

When using Kubernetes, we use a component called "ingress" that proxies queries to the pod. Hence, we need to specify the allowed body size for the ingress to proxy.

# Changes

| Q             | A        
|---------------| ---------
| Issue         | #442
| Type          | <ul><li>- [x] Feat</li><li>- [ ] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No



