### PR TITLE
fix: workflows action deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
  
     steps:
     - name: Build/Push
-      uses: coopTilleuls/action-docker-build-push@v4
+      uses: coopTilleuls/action-docker-build-push@v6 
       with:
         IMAGE_NAME: bikelib-php
         BUILD_CONTEXT: api
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Build/Push
-      uses: coopTilleuls/action-docker-build-push@v4
+      uses: coopTilleuls/action-docker-build-push@v6
       with:
         IMAGE_NAME: bikelib-caddy
         BUILD_CONTEXT: api
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Build/Push
-      uses: coopTilleuls/action-docker-build-push@v4
+      uses: coopTilleuls/action-docker-build-push@v6
       with:
         IMAGE_NAME: bikelib-pwa
         BUILD_CONTEXT: pwa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Pull images
         run: docker compose pull --ignore-pull-failures || true
       - name: pre-build api/app_php
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: "api"
           file: "api/Dockerfile"
@@ -29,7 +29,7 @@ jobs:
           push: false
           load: true
       - name: pre-build api/app_caddy
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: "api"
           file: "api/Dockerfile"
@@ -42,7 +42,7 @@ jobs:
           load: true
           tags: caddy
       - name: pre-build pwa_dev
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: "pwa"
           file: "pwa/Dockerfile"
@@ -52,7 +52,7 @@ jobs:
           push: false
           load: true
       - name: pre-build pwa prod
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: "pwa"
           file: "pwa/Dockerfile"


### PR DESCRIPTION
# Description

Cf https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


# Changes

| Q             | A        
|---------------| ---------
| Issue         | 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |   No





