### PR TITLE
Fix city and street input

### DIFF
--- a/pwa/pages/reparateur/inscription.tsx
+++ b/pwa/pages/reparateur/inscription.tsx
@@ -115,7 +115,7 @@ const RepairerRegistration: NextPageWithLayout<RepairerRegistrationProps> = ({
     },
     [setCitiesList]
   );
-  console.log(citiesList, streetList);
+
   useEffect(() => {
     if (cityInput === '' || cityInput.length < 3) {
       setCitiesList([]);


### PR DESCRIPTION
Change the params render input to display cities list and street list in autocomplete


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #33..
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





