### PR TITLE
fix: add READ group for createdAt property

### DIFF
--- a/api/src/Entity/Contact.php
+++ b/api/src/Entity/Contact.php
@@ -94,6 +94,7 @@ class Contact
 
     #[Assert\NotNull]
     #[ORM\Column]
+    #[Groups([self::READ])]
     public ?\DateTimeImmutable $createdAt;
 
     public function __construct()


### PR DESCRIPTION
# Description

To show the date in contact request in super admin dashboard, I added READ group for createdAt property


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #854 ..
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





