### PR TITLE
fix: show description field in bike identity

### DIFF
--- a/pwa/components/bike/BikeIdentity.tsx
+++ b/pwa/components/bike/BikeIdentity.tsx
@@ -33,7 +33,9 @@ const BikeIdentity = ({
   setBike,
   bikeTypes,
 }: BikeIdentityProps): JSX.Element => {
-  const [addDescription, setAddDescription] = useState<boolean>(false);
+  const [addDescription, setAddDescription] = useState<boolean>(
+    !!bike.description
+  );
   const [brand, setBrand] = useState<string>(bike.brand ? bike.brand : '');
   const [description, setDescription] = useState<string>(
     bike.description ? bike.description : ''
@@ -90,12 +92,13 @@ const BikeIdentity = ({
       if (brand) {
         bodyRequest['brand'] = brand;
       }
-      if (description) {
+      if (description !== bike.description) {
         bodyRequest['description'] = description;
       }
 
       bike = await bikeResource.put(bike['@id'], bodyRequest);
       setBike(bike);
+      setAddDescription(!!description);
     } catch (e: any) {
       setErrorMessage(
         `Mise à jour du vélo impossible:${e.message?.replace(errorRegex, '$2')}`
@@ -162,7 +165,7 @@ const BikeIdentity = ({
             inputProps={{maxLength: 255}}
             onChange={handleChangeBrand}
           />
-          {addDescription && (
+          {(description || addDescription) && (
             <TextField
               margin="normal"
               placeholder="Description de votre vélo"


### PR DESCRIPTION
# Description

fix: show description field in bike identity if description is already set. And we hide it if we update it with empty string.


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #865 ..
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





