### PR TITLE
fix: hide error message after close new appointment modal

### DIFF
--- a/pwa/components/dashboard/appointments/ModalAppointmentCreate.tsx
+++ b/pwa/components/dashboard/appointments/ModalAppointmentCreate.tsx
@@ -284,6 +284,7 @@ const ModalAppointmentCreate = ({
     setAddress('');
     setLatitude('');
     setLongitude('');
+    setErrorMessage(null);
     handleCloseModal(false);
   };
 


### PR DESCRIPTION
# Description

fix: hide error message after close new appointment modal


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #872 ..
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





