### PR TITLE
fix: upload photo and invoice in maintenance

### DIFF
--- a/api/docker/php/conf.d/app.ini
+++ b/api/docker/php/conf.d/app.ini
@@ -11,3 +11,6 @@ opcache.interned_strings_buffer = 16
 opcache.max_accelerated_files = 20000
 opcache.memory_consumption = 256
 opcache.enable_file_override = 1
+
+upload_max_filesize = 5M
+post_max_size = 5M

--- a/api/src/Entity/MediaObject.php
+++ b/api/src/Entity/MediaObject.php
@@ -118,6 +118,7 @@ class MediaObject
     public ?File $file = null;
 
     #[ORM\Column(nullable: true)]
+    #[Groups([self::MEDIA_OBJECT_READ, Repairer::REPAIRER_READ, Repairer::REPAIRER_COLLECTION_READ, Bike::READ, Maintenance::READ, Appointment::APPOINTMENT_READ, AutoDiagnostic::READ, Appointment::APPOINTMENT_READ, User::USER_READ])]
     public ?string $filePath = null;
 
     #[Assert\Choice(choices: ['private', 'public'], message: 'mediaObject.visibility.not_valid')]

--- a/pwa/interfaces/MediaObject.ts
+++ b/pwa/interfaces/MediaObject.ts
@@ -2,5 +2,6 @@ export interface MediaObject {
   '@id': string;
   '@type': string;
   contentUrl: string;
+  filePath: string;
   viewable: boolean;
 }


### PR DESCRIPTION
# Description

With POST : 
- we save photo and invoice on s3 server when they are upload on browser
- the photo and invoice are linked to maintenance when user submit form
- if user close modal without submit form, the photo and invoice are deleted

With PUT : 
- we save photo and invoice on s3 server when they are upload on browser
- the photo and maintenance are automatically linked to maintenance
- if user close modal without submit form, the photo and invoice are already saved and linked to maintenance

This PR correct also the limit weight for file we can send to the api

# Changes

| Q             | A        
|---------------| ---------
| Issue         | #621 & #702 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





