### PR TITLE
feat: adding confirmation when reload search repairer page

### DIFF
--- a/pwa/components/common/ConfirmationReloadDialog.tsx
+++ b/pwa/components/common/ConfirmationReloadDialog.tsx
@@ -1,0 +1,20 @@
+import {useEffect} from 'react';
+
+const ConfirmationReloadDialog = () => {
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+  return null;
+};
+
+export default ConfirmationReloadDialog;

--- a/pwa/pages/reparateur/chercher-un-reparateur.tsx
+++ b/pwa/pages/reparateur/chercher-un-reparateur.tsx
@@ -51,6 +51,7 @@ import {searchCity} from '@utils/apiCity';
 import {RepairerType} from '@interfaces/RepairerType';
 import {repairerTypeResource} from '@resources/repairerTypeResource';
 import {Repairer} from '@interfaces/Repairer';
+import ConfirmationReloadDialog from '@components/common/ConfirmationReloadDialog';
 
 type SearchRepairerProps = {
   bikeTypesFetched: BikeType[];
@@ -321,6 +322,7 @@ const SearchRepairer: NextPageWithLayout<SearchRepairerProps> = ({
         <title>Chercher un réparateur</title>
       </Head>
       <WebsiteLayout>
+        <ConfirmationReloadDialog />
         <Box
           bgcolor="lightprimary.light"
           height="100%"


### PR DESCRIPTION
# Description

adding confirmation when reload search repairer page

# Changes

| Q             | A        
|---------------| ---------
| Issue         | #
| Type          | <ul><li>- [x] Feat</li><li>- [ ] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





