### PR TITLE
fix: repairerCard width when only 1 result

### DIFF
--- a/pwa/pages/liste-des-reparateurs.tsx
+++ b/pwa/pages/liste-des-reparateurs.tsx
@@ -80,7 +80,8 @@ const RepairersList: NextPageWithLayout = ({
               container
               spacing={4}
               justifyContent="flex-start"
-              maxWidth="1200px">
+              maxWidth="1200px"
+              width="100%">
               {repairers.map((repairer) => {
                 return (
                   <Grid2
@@ -88,8 +89,7 @@ const RepairersList: NextPageWithLayout = ({
                     key={repairer.id}
                     xs={12}
                     md={6}
-                    width="100%"
-                    mx="auto">
+                    width="100%">
                     <RepairerCard
                       repairer={repairer}
                       onClick={() =>


### PR DESCRIPTION
# Description

repairerCard width when only 1 result


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #1014 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





