### PR TITLE
fix: prevent role duplication in back and front

### DIFF
--- a/api/fixtures/user.yaml
+++ b/api/fixtures/user.yaml
@@ -89,3 +89,19 @@ App\Entity\User:
     emailConfirmed: true
     street: <address()>
     city: <city()>
+  user_with_duplicated_roles:
+    roles: [
+      "ROLE_BOSS",
+      "ROLE_ADMIN",
+      "ROLE_USER",
+      "ROLE_BOSS",
+      "ROLE_ADMIN",
+      "ROLE_USER"
+    ]
+    email: "user-with-duplicated-roles@test.com"
+    firstName: 'Test'
+    lastName: 'Test'
+    plainPassword: "Test1passwordOk!"
+    emailConfirmed: true
+    street: <address()>
+    city: <city()>

--- a/api/src/Employees/State/CreateUserEmployeeProcessor.php
+++ b/api/src/Employees/State/CreateUserEmployeeProcessor.php
@@ -39,7 +39,7 @@ final class CreateUserEmployeeProcessor implements ProcessorInterface
         $user->plainPassword = $data->plainPassword ?: $this->generateRandomTempPassword();
         $user->email = $data->email;
         $user->emailConfirmed = true;
-        $user->roles = [User::ROLE_EMPLOYEE];
+        $user->addRole(User::ROLE_EMPLOYEE);
         // Validate the new entity
         $this->validator->validate($user);
 

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -114,7 +114,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     #[ORM\Column]
     #[Groups([self::USER_READ])]
-    public array $roles = ['ROLE_USER'];
+    private array $roles = ['ROLE_USER'];
 
     #[Assert\Type('boolean')]
     #[ORM\Column(type: 'boolean', nullable: false)]
@@ -214,11 +214,30 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function getRoles(): array
     {
-        $roles = $this->roles;
         // guarantee every user at least has ROLE_USER
-        $roles[] = 'ROLE_USER';
+        $this->addRole('ROLE_USER');
 
-        return array_unique($roles);
+        return array_unique($this->roles);
+    }
+
+    public function addRole(string $role): self
+    {
+        if (!in_array($role, $this->roles)) {
+            $this->roles[] = $role;
+        }
+
+        return $this;
+    }
+
+    public function removeRole(string $role): self
+    {
+        if (in_array($role, $this->roles)) {
+            $this->roles = array_filter($this->roles, function ($roleToCompare) use ($role) {
+                return $role !== $roleToCompare;
+            });
+        }
+
+        return $this;
     }
 
     public function eraseCredentials()
@@ -228,7 +247,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function isAdmin(): bool
     {
-        if (in_array(self::ROLE_ADMIN, $this->roles)) {
+        if (in_array(self::ROLE_ADMIN, $this->getRoles())) {
             return true;
         }
 
@@ -237,7 +256,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function isBoss(): bool
     {
-        if (in_array(self::ROLE_BOSS, $this->roles)) {
+        if (in_array(self::ROLE_BOSS, $this->getRoles())) {
             return true;
         }
 
@@ -246,7 +265,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     public function isEmployee(): bool
     {
-        if (in_array(self::ROLE_EMPLOYEE, $this->roles)) {
+        if (in_array(self::ROLE_EMPLOYEE, $this->getRoles())) {
             return true;
         }
 

--- a/api/src/Repairers/State/CreateUserRepairerProcessor.php
+++ b/api/src/Repairers/State/CreateUserRepairerProcessor.php
@@ -35,7 +35,7 @@ final class CreateUserRepairerProcessor implements ProcessorInterface
         $user->lastName = $data->lastName;
         $user->plainPassword = $data->plainPassword;
         $user->email = $data->email;
-        $user->roles = [User::ROLE_BOSS];
+        $user->addRole(User::ROLE_BOSS);
         // Validate the new entity
         $this->validator->validate($user);
 

--- a/api/src/Repairers/State/UpdateRepairerBossProcessor.php
+++ b/api/src/Repairers/State/UpdateRepairerBossProcessor.php
@@ -70,12 +70,12 @@ final readonly class UpdateRepairerBossProcessor implements ProcessorInterface
         $this->entityManager->remove($employeeExist);
 
         // Update old boss
-        $currentBoss->roles = [User::ROLE_EMPLOYEE];
+        $currentBoss->addRole(User::ROLE_EMPLOYEE);
         $currentBoss->repairer = null;
         $currentBoss->repairerEmployee = $newRepairerEmployee;
 
         // Set the new roles
-        $newBoss->roles = [User::ROLE_BOSS];
+        $newBoss->addRole(User::ROLE_BOSS);
         $repairer->owner = $newBoss;
         $this->validator->validate($repairer);
         $newBoss->repairerEmployee = null;

--- a/api/src/User/EventSubscriber/UpdateRoleSubscriber.php
+++ b/api/src/User/EventSubscriber/UpdateRoleSubscriber.php
@@ -46,11 +46,11 @@ final readonly class UpdateRoleSubscriber implements EventSubscriberInterface
         }
 
         if (in_array('ROLE_ADMIN', $contentRequest['roles'])) {
-            $user->roles[] = 'ROLE_ADMIN';
+            $user->addRole('ROLE_ADMIN');
         }
 
         if (in_array('ROLE_USER', $contentRequest['roles'])) {
-            $user->roles = ['ROLE_USER'];
+            $user->addRole('ROLE_USER');
         }
     }
 }

--- a/api/tests/Repairer/UpdateBossTest.php
+++ b/api/tests/Repairer/UpdateBossTest.php
@@ -62,11 +62,11 @@ class UpdateBossTest extends AbstractTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         // Check if boss became employee
         $this->assertSame($response['employee']['@id'], sprintf('/users/%d', $currentBossId));
-        $this->assertSame($response['employee']['roles'][0], 'ROLE_EMPLOYEE');
+        $this->assertContains('ROLE_EMPLOYEE', $response['employee']['roles']);
         $newRepairerEmployee = static::getContainer()->get(RepairerEmployeeRepository::class)->findOneBy(['id' => $response['id']]);
         // Check if employee became boss
         $this->assertSame($newRepairerEmployee->repairer->owner->id, $currentEmployeeId);
-        $this->assertSame($newRepairerEmployee->repairer->owner->roles, ['ROLE_BOSS']);
+        $this->assertContains('ROLE_BOSS', $newRepairerEmployee->repairer->owner->getRoles());
 
         // Check if repairerEmployee has been removed
         $repairerEmployeeNotFound = static::getContainer()->get(RepairerEmployeeRepository::class)->findOneBy(['employee' => $currentEmployeeId]);
@@ -87,12 +87,12 @@ class UpdateBossTest extends AbstractTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         // Check if boss became employee
         $this->assertSame($response['employee']['@id'], sprintf('/users/%d', $currentBossId));
-        $this->assertSame($response['employee']['roles'][0], 'ROLE_EMPLOYEE');
+        $this->assertContains('ROLE_EMPLOYEE', $response['employee']['roles']);
         $newRepairerEmployee = static::getContainer()->get(RepairerEmployeeRepository::class)->findOneBy(['id' => $response['id']]);
 
         // Check if employee became boss
         $this->assertSame($newRepairerEmployee->repairer->owner->id, $currentEmployeeId);
-        $this->assertSame($newRepairerEmployee->repairer->owner->roles, ['ROLE_BOSS']);
+        $this->assertContains('ROLE_BOSS', $newRepairerEmployee->repairer->owner->getRoles());
 
         // Check if repairerEmployee has been removed
         $repairerEmployeeNotFound = static::getContainer()->get(RepairerEmployeeRepository::class)->findOneBy(['employee' => $currentEmployeeId]);

--- a/api/tests/User/AssertUserTest.php
+++ b/api/tests/User/AssertUserTest.php
@@ -332,4 +332,26 @@ class AssertUserTest extends AbstractTestCase
             'hydra:description' => sprintf('email: %s', $this->translator->trans('user.email.unique', domain: 'validators')),
         ]);
     }
+
+    public function testAddRole(): void
+    {
+        $user = new User();
+        self::assertSame(['ROLE_USER'], $user->getRoles());
+
+        $user->addRole('ROLE_BOSS');
+        self::assertSame(['ROLE_USER', 'ROLE_BOSS'], $user->getRoles());
+
+        $user->addRole('ROLE_USER');
+        self::assertSame(['ROLE_USER', 'ROLE_BOSS'], $user->getRoles());
+    }
+
+    public function testRemoveRole(): void
+    {
+        $user = new User();
+        $user->addRole('ROLE_BOSS');
+        self::assertSame(['ROLE_USER', 'ROLE_BOSS'], $user->getRoles());
+
+        $user->removeRole('ROLE_BOSS');
+        self::assertSame(['ROLE_USER'], $user->getRoles());
+    }
 }

--- a/api/tests/User/GetCurrentUserTest.php
+++ b/api/tests/User/GetCurrentUserTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\User;
 
+use App\Entity\User;
+use App\Repository\UserRepository;
 use App\Tests\AbstractTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -45,5 +47,19 @@ class GetCurrentUserTest extends AbstractTestCase
         $this->assertResponseIsSuccessful();
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
         $this->assertIsArray($response['lastRepairers']);
+    }
+
+    public function testGetCurrentUserWithDuplicatedRolesIsCorrectlyFormatted(): void
+    {
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        /** @var User $user */
+        $user = $userRepository->findOneBy(['email' => 'user-with-duplicated-roles@test.com']);
+
+        $this->createClientWithUser($user)->request('GET', '/me');
+
+        self::assertJsonContains([
+            'roles' => ['ROLE_USER', 'ROLE_BOSS', 'ROLE_ADMIN'],
+        ]);
     }
 }

--- a/pwa/helpers/rolesHelpers.ts
+++ b/pwa/helpers/rolesHelpers.ts
@@ -6,15 +6,21 @@ export const isCyclist = (user: User): boolean => {
 };
 
 export const isBoss = (user: User): boolean => {
-  return user.roles.includes('ROLE_BOSS');
+  return Array.isArray(user.roles)
+    ? user.roles.includes('ROLE_BOSS')
+    : Object.values(user.roles).includes('ROLE_BOSS');
 };
 
 export const isEmployee = (user: User): boolean => {
-  return user.roles.includes('ROLE_EMPLOYEE');
+  return Array.isArray(user.roles)
+    ? user.roles.includes('ROLE_EMPLOYEE')
+    : Object.values(user.roles).includes('ROLE_EMPLOYEE');
 };
 
 export const isAdmin = (user: User): boolean => {
-  return user.roles.includes('ROLE_ADMIN');
+  return Array.isArray(user.roles)
+    ? user.roles.includes('ROLE_ADMIN')
+    : Object.values(user.roles).includes('ROLE_ADMIN');
 };
 
 export const isItinerant = (user: User): boolean => {


### PR DESCRIPTION
# Description

- set roles property as private to force to use getRoles() instead
- add addRole() and removeRole()
- in front, check if roles are array or object before to check a role


# Changes

| Q             | A        
|---------------| ---------
| Issue         | 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [x] Refacto</li></ul>
| Break changes |  No





