### PR TITLE
fix: update caddy to 2.7.6 for cve 2024-22189

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -101,7 +101,7 @@ RUN set -eux; \
 RUN rm -f .env.local.php
 
 # Build Caddy with the Mercure and Vulcain modules
-FROM caddy:2.7-builder-alpine AS app_caddy_builder
+FROM caddy:2.7.6-builder-alpine AS app_caddy_builder
 
 RUN xcaddy build v2.7.6 \
 	--with github.com/dunglas/mercure/caddy \


### PR DESCRIPTION
# Description

Update caddy to v2.7.6


# Changes

| Q             | A        
|---------------| ---------
| Issue         | #
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





