### PR TITLE
fix: update caddy to 2.7.6 for cve 2024-22189

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -101,14 +101,14 @@ RUN set -eux; \
 RUN rm -f .env.local.php
 
 # Build Caddy with the Mercure and Vulcain modules
-FROM caddy:2.7-builder-alpine AS app_caddy_builder
+FROM caddy:2.7.6-builder-alpine AS app_caddy_builder
 
 RUN xcaddy build v2.7.6 \
 	--with github.com/dunglas/mercure/caddy \
 	--with github.com/dunglas/vulcain/caddy
 
 # Caddy image
-FROM caddy:2-alpine AS app_caddy
+FROM caddy:2.7.6-alpine AS app_caddy
 
 # needed for security update until base image is updated
 RUN apk upgrade libcurl curl openssl openssl-dev libressl libcrypto1.1 libssl1.1 libcrypto3 libssl3


### PR DESCRIPTION
# Description

update caddy to 2.7.6


# Changes

| Q             | A        
|---------------| ---------
| Issue         | 
| Type          | <ul><li>- [ ] Feat</li><li>- [x] Hotfix</li><li>- [ ] Doc</li><li>- [ ] Refacto</li></ul>
| Break changes |  No





